### PR TITLE
Fix/non detructive unless redirect

### DIFF
--- a/lib/rack/i18n_locale_switcher.rb
+++ b/lib/rack/i18n_locale_switcher.rb
@@ -91,8 +91,8 @@ module Rack
     
     def extract_locale_from_param(env)
       query_string = env['QUERY_STRING'].gsub(/\b#{ @param }=#{ LOCALE_PATTERN }(?:&|$)/, '')
-
-      if locale = available_locale($1, $2)
+      locale = available_locale($1, $2)
+      if locale && @redirect
         env['QUERY_STRING'] = query_string.gsub(/&$/, '')        
       end
       locale
@@ -100,8 +100,8 @@ module Rack
 
     def extract_locale_from_path(env)
       path_info = env['PATH_INFO'].gsub(/^\/#{ LOCALE_PATTERN }\b/, '')
-
-      if locale = available_locale($1, $2)
+      locale = available_locale($1, $2)
+      if locale && @redirect
         env['PATH_INFO'] = path_info
       end
       locale
@@ -111,8 +111,8 @@ module Rack
       env['HTTP_HOST'] ||= "#{ env['SERVER_NAME'] }:#{ env['SERVER_PORT'] }"            
 
       http_host = env['HTTP_HOST'].gsub(/^#{ LOCALE_PATTERN }\./, '')
-
-      if locale = available_locale($1, $2)
+      locale = available_locale($1, $2)
+      if locale && @redirect
         env['HTTP_HOST']   = http_host
         env['SERVER_NAME'] = http_host.gsub(/:\d+$/, '')
       end

--- a/spec/rack/i18n_locale_switcher_spec.rb
+++ b/spec/rack/i18n_locale_switcher_spec.rb
@@ -86,6 +86,17 @@ describe Rack::I18nLocaleSwitcher do
       I18n.locale.should eql(:es)
     end
 
+    it 'should not change the query string unless redirect is used' do
+      get "http://example.com?locale=de"
+      last_request.env['QUERY_STRING'].should eql('locale=de')
+
+      get "http://example.com?locale=en-US"
+      last_request.env['QUERY_STRING'].should eql('locale=en-US')
+
+      get "http://example.com/some/path?foo=bar&locale=es&param=value"
+      last_request.env['QUERY_STRING'].should eql('foo=bar&locale=es&param=value')
+    end
+
     it "should not set an unavailable locale" do
       get "http://example.com?locale=xx"
       I18n.locale.should eql(I18n.default_locale)
@@ -113,6 +124,14 @@ describe Rack::I18nLocaleSwitcher do
       get "http://example.com/en-us"
       I18n.locale.should eql(:'en-US')
     end
+
+    it 'should not change path if not using redirect' do
+      get "http://example.com/de/some/path/"
+      last_request.env['PATH_INFO'].should eql('/de/some/path/')
+
+      get "http://example.com/en-us"
+      last_request.env['PATH_INFO'].should eql('/en-us')
+    end
   end
 
   context "from host" do
@@ -123,6 +142,17 @@ describe Rack::I18nLocaleSwitcher do
 
       get "http://de-de.example.com/"
       I18n.locale.should eql(:'de-DE')
+    end
+
+    it "should not change host if not using redirect" do
+      get "http://de.example.com/"
+      last_request.env['SERVER_NAME'].should eql('de.example.com')
+      last_request.env['HTTP_HOST'].should eql('de.example.com')
+
+      get "http://de-de.example.com/"
+      I18n.locale.should eql(:'de-DE')
+      last_request.env['SERVER_NAME'].should eql('de-de.example.com')
+      last_request.env['HTTP_HOST'].should eql('de-de.example.com')
     end
   end
 


### PR DESCRIPTION
### What does this PR do?

The current master would modify the env of rack even if not necessary.
Now path, host and query string stay untouched unless the settings of the Rack middleware ask for a redirect after extraction.